### PR TITLE
feat: adding status for kp get

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,7 +23,8 @@ yargs
         {
             name: { alias: 'n', type: 'string', desc: 'pod name', positional: true },
             label: { alias: 'l', type: 'string', desc: 'label to group by', default: 'subsystem' },
-            filter: { alias: 'f', type: 'string', desc: 'filter'  },
+            filter: { alias: 'f', type: 'string', desc: 'filter pods by name'  },
+            status: { alias: 's', type: 'string', desc: 'filter pods by status'  },
         }, async argv => {
             argv.name = argv._[1] || argv.name;
             if (argv.name) {
@@ -31,7 +32,7 @@ yargs
             } else if(argv.filter) {
                 await getPodFilter(argv, banner);
             } else {
-                await getPods(argv, banner)
+                await getPods(argv, banner, argv.status)
             }
         })
     .command(['logs <name>', 'l'], 'Get pod logs', {}, async argv => {
@@ -40,10 +41,11 @@ yargs
     .command(['exec <name>'], 'Exec pod', {}, async argv => {
         return await execPod(argv, banner);
     })
-    .example('$0 get', 'get all pods in env')
-    .example('$0 get -e dev', 'get pods in dev namespace')
-    .example('$0 get [name]', 'get pod specific info')
-    .example('$0 get --filter views', 'get pods specific info filtered by name')
+    .example('$0 get', 'get pods list in env')
+    .example('$0 get -e dev', 'get pods list in dev namespace')
+    .example('$0 get -s failed', 'get pods list with failed status')
+    .example('$0 get [pod-name]', 'get a single pod specific info for [pod-name]')
+    .example('$0 get -f views', 'get pods specific info filtered by name')
     .option('env', { alias: 'e', type: 'string', default: process.env.KP_ENV || 'KP_ENV', desc: 'env to get pods', required: true })
     .option('url', { alias: 'u', type: 'string', default: 'KP_URL', desc: 'k8s dashboard url', required: true })
     .option('token', { alias: 't', type: 'string', default: 'KP_TOKEN', desc: 'bearer token', required: true })


### PR DESCRIPTION
provide the ability to get a list of pods based on status.

status being one of:
* Running
* Failed
* Pending

usage: 
`kp get -s failed`

input and reference are lowercased before comparison